### PR TITLE
Fix OpenNext build by removing edge runtime

### DIFF
--- a/src/app/api/contact/route.js
+++ b/src/app/api/contact/route.js
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { Resend } from 'resend';
 
-export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
 const resend = new Resend(process.env.RESEND_API_KEY);


### PR DESCRIPTION
## Summary
- fix the contact API route for OpenNext deployment

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68809392d46c8333bbd5b31a02f6d641