### PR TITLE
Fix export syntax

### DIFF
--- a/src/utils/siteMetaData.js
+++ b/src/utils/siteMetaData.js
@@ -18,6 +18,6 @@ const siteMetadata = {
     linkedin: 'https://www.linkedin.com/company/radii-lab',
     // dribbble: 'https://www.dribbble.com',
     locale: 'en-US',
-  }
-  
-  module.exports = siteMetadata
+}
+
+export default siteMetadata


### PR DESCRIPTION
## Summary
- use ES module default export in site metadata

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'map'))*

------
https://chatgpt.com/codex/tasks/task_e_68809f53e5ec8333a4c6121d396fbc35